### PR TITLE
fix: add missing callback invocation in postAceInit hook

### DIFF
--- a/static/js/disable_error_messages.js
+++ b/static/js/disable_error_messages.js
@@ -8,4 +8,5 @@ exports.postAceInit = (hookName, args, cb) => {
         }
         </style>
         `);
+  return cb();
 };


### PR DESCRIPTION
Found during a systematic audit of all Etherpad plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)