### PR TITLE
revert: drop npm_config_strict_dep_builds workaround

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -17,11 +17,6 @@ jobs:
     permissions:
       contents: write   # for the atomic version-bump push (branch + tag)
       id-token: write   # for npm OIDC trusted publishing
-    env:
-      # pnpm 10.7+ treats ignored postinstalls as hard errors. Demote
-      # to warning so new transitive deps (e.g. unrs-resolver) don\'t break
-      # the release step.
-      npm_config_strict_dep_builds: "false"
     steps:
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
The upstream fix in ether/eslint-config-etherpad has landed (4.0.5 dropped the transitive that triggered ERR_PNPM_IGNORED_BUILDS). The job-level `npm_config_strict_dep_builds` env var is no longer needed — reverting it keeps the workflow clean.

Generated with [Claude Code](https://claude.com/claude-code)