### PR TITLE
docs: add README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,19 @@
 
 Disables the gritter popup errors messages so your users will never know how broken your install is <3 :)
 
+## Installation
 
+Install from the Etherpad admin UI (**Admin → Manage Plugins**,
+search for `ep_disable_error_messages` and click *Install*), or from the Etherpad
+root directory:
+
+```sh
+pnpm run plugins install ep_disable_error_messages
+```
+
+> ⚠️ Don't run `npm i` / `npm install` yourself from the Etherpad
+> source tree — Etherpad tracks installed plugins through its own
+> plugin-manager, and hand-editing `package.json` can leave the
+> server unable to start.
+
+After installing, restart Etherpad.


### PR DESCRIPTION
Many operators reach for `npm i ep_<plugin>` because the README doesn't document the install flow — but that bypasses Etherpad's plugin-manager and typically leaves the server unable to start (cf. ether/ep_table_of_contents#154). Add a short uniform Installation section pointing at the admin UI / `pnpm run plugins install` and explicitly warning against hand-editing `package.json`.