### PR TITLE
chore: declare @feature:error-gritter disable + use disables-aware test runner

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -69,4 +69,10 @@ jobs:
           done
           cd src
           pnpm exec playwright install chromium --with-deps
-          pnpm run test-ui --project=chromium
+          # Use the declared-disables helper instead of plain test-ui:
+          # ep.json declares `disables: ["@feature:error-gritter"]`, so the
+          # helper runs two passes — regression (everything not tagged
+          # @feature:error-gritter must pass) + honesty (every test
+          # tagged @feature:error-gritter must FAIL because the plugin
+          # disables error gritter messages). See doc/PLUGIN_FEATURE_DISABLES.md.
+          ../bin/run-frontend-tests-with-disables.sh -- --project=chromium

--- a/ep.json
+++ b/ep.json
@@ -1,5 +1,5 @@
-
 {
+  "disables": ["@feature:error-gritter"],
   "parts":[
     {
       "name": "ep_disable_error_messages",


### PR DESCRIPTION
Mirrors [ep_disable_chat#75](https://github.com/ether/ep_disable_chat/pull/75) (merged, shipped v0.0.40) and [ep_disable_change_author_name#84](https://github.com/ether/ep_disable_change_author_name/pull/84).

## Changes
- `ep.json` declares `"disables": ["@feature:error-gritter"]` so etherpad.org/plugins and Etherpad's /admin UI surface what this plugin removes before install.
- `.github/workflows/frontend-tests.yml` swaps `pnpm run test-ui` for `../bin/run-frontend-tests-with-disables.sh -- --project=chromium`. The helper runs every spec NOT tagged `@feature:error-gritter` (regression — must pass) and every spec tagged with it (honesty — fail-fast on first failure proves the plugin actually suppresses error gritters).

See [the contract proposal](https://github.com/ether/etherpad/pull/7648) and `doc/PLUGIN_FEATURE_DISABLES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)