### PR TITLE
ci: trigger release after Dependabot Automerge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -2,6 +2,12 @@ name: Dependabot Automerge
 permissions:
   contents: write
   pull-requests: write
+  # `actions: write` lets the post-merge step kick off Node.js Package on
+  # the default branch via `gh workflow run`. Without this, automerge'd
+  # PRs land on main but the on-push release job never fires (GitHub
+  # Actions intentionally suppresses on:push triggers when the push is
+  # authenticated with GITHUB_TOKEN).
+  actions: write
 on:
   workflow_run:
     workflows:
@@ -21,6 +27,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Automerge
+        id: automerge
         uses: "pascalgn/automerge-action@v0.16.4"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -28,3 +35,11 @@ jobs:
           MERGE_LABELS: ""
           MERGE_RETRY_SLEEP: "100000"
 
+      - name: Trigger release on default branch
+        # `pascalgn/automerge-action` exits 0 whether or not it merged. Skip
+        # the dispatch when nothing was actually merged so we don't kick a
+        # phantom release run on every Dependabot Automerge invocation.
+        if: steps.automerge.outputs.mergeResult == 'merged'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run test-and-release.yml --ref ${{ github.event.repository.default_branch }}

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -1,5 +1,11 @@
 name: Node.js Package
-on: [push]
+on:
+  push:
+  # Invoked by automerge.yml after a Dependabot PR is merged. GitHub
+  # Actions doesn't fire on:push when the push is authored by GITHUB_TOKEN
+  # (the automerge action's only available identity), so without this
+  # dispatch trigger the release job never runs after auto-merges.
+  workflow_dispatch:
 
 # id-token: write must be granted here so the reusable npmpublish workflow
 # can request an OIDC token for npm trusted publishing.


### PR DESCRIPTION
Mirrors [ep_announce#114](https://github.com/ether/ep_announce/pull/114) (already merged + verified end-to-end).

## Why

GitHub Actions intentionally suppresses `on: push` workflows when the push is authenticated with `GITHUB_TOKEN`. `pascalgn/automerge-action` only has GITHUB_TOKEN, so when it merges a Dependabot PR the resulting push **doesn't** trigger `Node.js Package` and the version-bump + npm-publish job never runs.

## Fix

- `automerge.yml` grows `actions: write` and a final step that calls `gh workflow run test-and-release.yml --ref <default-branch>`, gated on `mergeResult == 'merged'`.
- `test-and-release.yml` grows a `workflow_dispatch:` trigger so the dispatch above has something to invoke. Existing `on: push` is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)